### PR TITLE
chore: add .coveragerc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: [
+          '3.9',
+          '3.10'
+        ]
         poetry-version: [1.1.13]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [
+          ubuntu-latest, 
+          macos-latest, 
+          windows-latest
+        ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -38,23 +45,17 @@ jobs:
 
       - name: Install Dependencies
         run: poetry install
-
+        
       - name: Test
-        run: poetry run pytest --cov=melnor_bluetooth
+        run: poetry run pytest --cov --cov-report=xml:${{ matrix.python-version }}_${{ matrix.os }}.xml
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
-        uses: AndreMiras/coveralls-python-action@develop
+      - name: Upload coverage
+        uses: codecov/codecov-action@v2
         with:
-          parallel: true
-          flag-name: run-${{ matrix.toxenv }}
+          files: ./${{ matrix.python-version }}_${{ matrix.os }}.xml # optional
+          flags: Unit Tests # optional
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
 
-  finish:
-    needs: test
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
-      with:
-        parallel-finished: true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 description = "A small python library for discovery and interacting with Melnor, Aquastar, etc bluetooth water timers."
 authors = ["Justin Vanderhooft <justinvdhooft@gmail.com>"]
 
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.coverage.run]
+relative_files = true
+
 [tool.poetry.dependencies]
 python = "^3.9"
 bleak = "^0.14.2"
@@ -12,7 +19,3 @@ bleak = "^0.14.2"
 pytest = "^7.0.0"
 black = "^22.1.0"
 pytest-cov = "^3.0.0"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
the 3rd party coveralls uploader isn't well maintained and sucks. codacy officially supplies an uploader for GHA. so we'll use that.