### PR TITLE
refactor: pass around BLEDevice instead of address

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3,24 +3,22 @@ import sys
 from typing import List
 
 import aioconsole
+from bleak.backends.device import BLEDevice
 
 from melnor_bluetooth.device import Device
 from melnor_bluetooth.scanner import scanner
 
-address = "FDBC1347-8D0B-DB0E-8D79-7341E825AC2A"
-
 devices: List[Device] = []
 
 
-def detection_callback(address: str):
-    # if advertisement_data.local_name is not None:
-    #     if "YM Timer" in advertisement_data.local_name:
+def detection_callback(ble_device: BLEDevice):
+
+    address = ble_device.address
 
     has_device = [d for d in devices if d.mac == address]
 
     if len(has_device) == 0:
-        print(address)
-        device = Device(address)
+        device = Device(address, ble_device)
         devices.append(device)
         print(f"Found device: {device.__str__()}")
 

--- a/melnor_bluetooth/scanner.py
+++ b/melnor_bluetooth/scanner.py
@@ -2,11 +2,11 @@ import asyncio
 import sys
 from typing import Callable
 
-from bleak import BleakScanner
+from bleak import BleakScanner  # type: ignore - this is a valid import
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
-DeviceCallbackType = Callable[[str], None]
+DeviceCallbackType = Callable[[BLEDevice], None]
 
 lock = asyncio.Lock()
 
@@ -18,12 +18,12 @@ def _callback(
 ):
     if ble_advertisement_data.manufacturer_data.get(13) is not None:
 
-        #  we need to ignore the aadvertisement data for now
+        #  we need to ignore the advertisement data for now
         # https://github.com/vanstinator/melnor-bluetooth/issues/17
         # data = ble_advertisement_data.manufacturer_data[13]
         # model_number = f"{data[0]:02x}{data[1]:02x}"
 
-        callback(ble_device.address)
+        callback(ble_device)
 
 
 async def scanner(

--- a/tests/test_device_valves.py
+++ b/tests/test_device_valves.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 import freezegun
 import pytest
-from bleak import BleakClient
+from bleak import BleakClient  # type: ignore - this is a valid import
 from mockito import ANY, expect, mock, verify, when
 
 import melnor_bluetooth.device as device_module
@@ -62,7 +62,7 @@ def client_mock() -> Type:
 
 class TestValveZone:
     def test_zone_update_state(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         device.zone1.update_state(zone_manual_setting_bytes, VALVE_MANUAL_SETTINGS_UUID)
 
@@ -70,14 +70,14 @@ class TestValveZone:
         assert device.zone1.manual_watering_minutes == 5
 
     def test_zone_properties(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         device.zone1.is_watering = True
 
         assert device.zone1.manual_watering_minutes == 20
 
     def test_zone_defaults(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         zone = Valve(0, device)
 
@@ -85,7 +85,7 @@ class TestValveZone:
         assert zone.manual_watering_minutes == 20
 
     def test_zone_byte_payload(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
         zone = Valve(0, device)
 
         zone.is_watering = True
@@ -97,7 +97,7 @@ class TestValveZone:
 class TestDevice:
     async def test_properties(self, client_mock):
 
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         await device.connect()
 
@@ -107,7 +107,7 @@ class TestDevice:
         assert device.valve_count == 4
 
     async def test_get_item(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         await device.connect()
 
@@ -124,7 +124,7 @@ class TestDevice:
             read_manufacturer
         )
 
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         await device.connect()
 
@@ -135,7 +135,7 @@ class TestDevice:
 
     async def test_2_valve_device(self, client_mock):
 
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         read_manufacturer = asyncio.Future()
         read_manufacturer.set_result(b"111110200")
@@ -159,7 +159,7 @@ class TestDevice:
             read_manufacturer
         )
 
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         await device.connect()
 
@@ -184,7 +184,7 @@ class TestDevice:
             read_manufacturer
         )
 
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         await device.connect()
 
@@ -202,7 +202,7 @@ class TestDevice:
 
     async def test_device_connect_lock(self, client_mock):
         with expect(BleakClient, times=1).connect():
-            device = Device(mac=TEST_UUID)
+            device = Device(address=TEST_UUID, ble_device=None)
 
             success = asyncio.Future()
 
@@ -232,7 +232,7 @@ class TestDevice:
     async def test_device_connect_noop_when_connected(self, client_mock):
         with expect(BleakClient, times=1).connect():
 
-            device = Device(mac=TEST_UUID)
+            device = Device(address=TEST_UUID, ble_device=None)
 
             success = asyncio.Future()
             success.set_result(True)
@@ -255,7 +255,7 @@ class TestDevice:
 
     @freezegun.freeze_time(datetime.datetime.now(tz=ZoneInfo("UTC")))
     async def test_fetch(self, client_mock):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         read_battery = asyncio.Future()
         read_battery.set_result(b"\x02\x85")
@@ -349,7 +349,7 @@ class TestDevice:
         assert device.zone4.watering_end_time == 0
 
     def test_str(self, snapshot):
-        device = Device(mac=TEST_UUID)
+        device = Device(address=TEST_UUID, ble_device=None)
 
         actual = device.__str__()
 


### PR DESCRIPTION
Home Assistant 2022.8.x added official `bluetooth` integration. Even better, it's based on `bleak`!

Following the [dev guide and best practices](https://developers.home-assistant.io/docs/network_discovery#best-practices-for-library-authors) this is the first bit of refactoring necessary to get the library hooked up.

The primary change right now is passing a `BLEDevice` to the melnor `Device` class constructor, rather than an address. Apparently this will allow us to connect to devices without initiating a background scan, which was likely biting us on the current code with some of the issues surrounding connections and locking up the bluetooth radio.

Also cleaned up some of the locks. We'd had some creep in a prior PR with some weird duplicate nested locks that weren't necessary. Now we just share a single global lock for the device across the entire event loop. Should continue to prevent some of the weird lockups we were seeing with multiple devices previously, while being simpler than the old state.