### PR TITLE
feat: add locked property setter for valves

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ from typing import List
 import aioconsole
 from bleak.backends.device import BLEDevice
 
-from melnor_bluetooth.device import Device
+from melnor_bluetooth.device import Device, Valve
 from melnor_bluetooth.scanner import scanner
 from melnor_bluetooth.utils.formatter import CustomFormatter
 
@@ -33,7 +33,7 @@ def detection_callback(ble_device: BLEDevice):
 
 async def main():
 
-    await scanner(detection_callback, scan_timeout_seconds=20)
+    await scanner(detection_callback, scan_timeout_seconds=10)
 
     if len(devices) == 0:
         _LOGGER.warning("No devices found")
@@ -72,12 +72,12 @@ async def main():
 
             _LOGGER.info("Setting zone %s to %s for %s minutes", zone, state, minutes)
             if minutes is not None:
-                valve.manual_watering_minutes = int(minutes)
+                await valve.async_update_prop(Valve.manual_watering_minutes, int(1))
 
             if state is None:
-                valve.is_watering = not valve.is_watering
+                await valve.async_update_prop(Valve.is_watering, not valve.is_watering)
             else:
-                valve.is_watering = state == "on"
+                await valve.async_update_prop(Valve.is_watering, state == "on")
 
             await device.push_state()
 

--- a/cli.py
+++ b/cli.py
@@ -72,12 +72,17 @@ async def main():
 
             _LOGGER.info("Setting zone %s to %s for %s minutes", zone, state, minutes)
             if minutes is not None:
-                await valve.async_update_prop(Valve.manual_watering_minutes, int(1))
+                await valve.async_set_prop_and_update(
+                    Valve.manual_watering_minutes, int(1)
+                )
 
             if state is None:
-                await valve.async_update_prop(Valve.is_watering, not valve.is_watering)
+                await valve.async_set_prop_and_update(
+                    Valve.is_watering, not valve.is_watering
+                )
+
             else:
-                await valve.async_update_prop(Valve.is_watering, state == "on")
+                await valve.async_set_prop_and_update(Valve.is_watering, state == "on")
 
             await device.push_state()
 

--- a/melnor_bluetooth/device.py
+++ b/melnor_bluetooth/device.py
@@ -136,9 +136,8 @@ class Valve:
         self._end_time = value
 
     @bluetooth_lock
-    async def async_update_prop(self, prop: property, value: Any) -> None:
-        """Grabs a global lock before updating the internal state of the valve and
-        subsequently pushing that said to the device"""
+    async def async_set_prop_and_update(self, prop: property, value: Any) -> None:
+        """Safely updates the property and pushes the new state to the device"""
 
         if prop.fset is None:
             raise AttributeError(f"Can't set attribute {prop}")
@@ -182,6 +181,8 @@ class Device:
 
     def __init__(self, ble_device: BLEDevice) -> None:
 
+        self.test = dir(Valve)
+        self.test
         self._battery = 0
         self._ble_device = ble_device
         self._is_connected = False

--- a/melnor_bluetooth/scanner.py
+++ b/melnor_bluetooth/scanner.py
@@ -23,6 +23,9 @@ def _callback(
 ):
     if ble_advertisement_data.manufacturer_data.get(13) is not None:
 
+        if ble_device.address == "C52127E4-C39B-D0A0-22BD-5837BC84AB9C":
+            return
+
         #  we need to ignore the advertisement data for now
         # https://github.com/vanstinator/melnor-bluetooth/issues/17
         # data = ble_advertisement_data.manufacturer_data[13]


### PR DESCRIPTION
Address race conditions in Home Assistant where a state change gets stomped out by a refresh due to the state change not being locked.