### PR TITLE
refactor: clean up setters and deprecate older functions

### DIFF
--- a/melnor_bluetooth/utils/lock.py
+++ b/melnor_bluetooth/utils/lock.py
@@ -1,0 +1,21 @@
+import asyncio
+from functools import wraps
+from typing import Any, Callable, Coroutine, TypeVar
+
+GLOBAL_BLUETOOTH_LOCK: asyncio.Lock = asyncio.Lock()  # type: ignore
+
+RT = TypeVar("RT")
+
+
+def bluetooth_lock(
+    func: Callable[..., Coroutine[Any, Any, RT]]
+) -> Callable[..., Coroutine[Any, Any, RT]]:
+    """Decorator to lock bluetooth operations."""
+
+    @wraps(func)
+    async def wrapped(*args, **kwargs) -> RT:
+
+        async with GLOBAL_BLUETOOTH_LOCK:
+            return await func(*args, **kwargs)
+
+    return wrapped

--- a/poetry.lock
+++ b/poetry.lock
@@ -151,6 +151,20 @@ python-versions = ">=3.7,<4.0"
 docs = ["sphinxcontrib-fulltoc[docs] (>=1.2.0,<2.0.0)", "sphinxcontrib-asyncio[docs] (>=0.3.0,<0.4.0)", "sphinx-rtd-theme[docs] (>=1.0.0,<2.0.0)", "myst-parser[docs] (>=0.18.0,<0.19.0)", "Sphinx[docs] (>=5.1.1,<6.0.0)"]
 
 [[package]]
+name = "deprecated"
+version = "1.2.13"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -645,10 +659,18 @@ platformdirs = ">=2.4,<3"
 docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
+[[package]]
+name = "wrapt"
+version = "1.14.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "09f71107080942cab5e031f209c49d63f8dbfc7118d2a9007a19967afc4c5ca2"
+content-hash = "d6ad7eeb93e6176ac2bd2ec08b647ace41d6fdba9a90a25d7dda51239feda53a"
 
 [metadata.files]
 aioconsole = []
@@ -664,6 +686,7 @@ colorama = []
 colored = []
 coverage = []
 dbus-fast = []
+deprecated = []
 distlib = []
 dunamai = []
 filelock = []
@@ -709,3 +732,4 @@ typing-extensions = []
 tzdata = []
 tzlocal = []
 virtualenv = []
+wrapt = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ tzdata = ">=2022.1"
 tzlocal = ">=4.1"
 aioconsole = ">=0.4.1"
 bleak-retry-connector = ">=1.11.0"
+Deprecated = ">=1.2.13"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/tests/test_device_valves.py
+++ b/tests/test_device_valves.py
@@ -136,10 +136,10 @@ class TestValveZone:
                 zone_manual_setting_bytes, VALVE_MANUAL_SETTINGS_UUID
             )
 
-            assert device.zone1.is_watering == True
+            assert device.zone1.is_watering is True
             assert device.zone1.manual_watering_minutes == 5
 
-    async def test_zone_properties(self, ble_device_mock):
+    async def test_atomic_zone_setters(self, ble_device_mock):
 
         with patch_establish_connection():
 
@@ -149,6 +149,18 @@ class TestValveZone:
             await device.zone1.set_is_watering(True)
 
             assert device.zone1.manual_watering_minutes == 20
+
+    async def test_zone_properties(self, ble_device_mock):
+
+        with patch_establish_connection():
+
+            device = Device(ble_device=ble_device_mock)
+            await device.connect()
+
+            device.zone1.is_watering = True
+            device.zone1.manual_watering_minutes = 10
+
+            assert device.zone1.manual_watering_minutes == 10
 
     async def test_zone_defaults(self, ble_device_mock):
         with patch_establish_connection():


### PR DESCRIPTION
Add back the setters that were deleted in #36 but mark them as deprecated with handy cli warnings for end users.